### PR TITLE
chore: add npmrc to remove pnpm lockfile

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+lockfile = false


### PR DESCRIPTION
This adds a .npmrc config file to disable the generation of a lockfile when running `pnpm install`.